### PR TITLE
fix bug in AZTabBarButton.layoutSubviews() which reversed the meaning…

### DIFF
--- a/AZTabBarController/ViewController.swift
+++ b/AZTabBarController/ViewController.swift
@@ -190,7 +190,7 @@ extension ViewController: AZTabBarDelegate{
     }
     
     func tabBar(_ tabBar: AZTabBarController, shouldAnimateButtonInteractionAtIndex index: Int) -> Bool {
-        return false
+        return true
     }
     
     func tabBar(_ tabBar: AZTabBarController, didMoveToTabAtIndex index: Int) {

--- a/Sources/AZTabBarButton.swift
+++ b/Sources/AZTabBarButton.swift
@@ -105,12 +105,11 @@ public class AZTabBarButton: UIButton{
         self.imageView?.frame = self.imageRect(forContentRect: self.frame)
         
         if animate {
+          UIView.animate(withDuration: 0.1) {
             super.layoutSubviews()
+          }
         }else{
-            UIView.animate(withDuration: 0.1) {
-                
-                super.layoutSubviews()
-            }
+          super.layoutSubviews()
         }
         
     }


### PR DESCRIPTION
… of delegate.shouldAnimate()

changed the example so that it continues to demonstrate animated behavior